### PR TITLE
[ch #145177357] Add coveralls badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/andela/Healthchecks_Asgardians/badge.svg?branch=master)](https://coveralls.io/github/andela/Healthchecks_Asgardians?branch=master)
 
+[![Code Issues](https://www.quantifiedcode.com/api/v1/project/3881de30758e48fdb432eefe9f321896/badge.svg)](https://www.quantifiedcode.com/app/project/3881de30758e48fdb432eefe9f321896)
+
 ![Screenshot of Welcome page](/stuff/screenshots/welcome.png?raw=true "Welcome Page")
 
 ![Screenshot of My Checks page](/stuff/screenshots/my_checks.png?raw=true "My Checks Page")

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # healthchecks
 
+[![Coverage Status](https://coveralls.io/repos/github/andela/Healthchecks_Asgardians/badge.svg?branch=master)](https://coveralls.io/github/andela/Healthchecks_Asgardians?branch=master)
+
 ![Screenshot of Welcome page](/stuff/screenshots/welcome.png?raw=true "Welcome Page")
 
 ![Screenshot of My Checks page](/stuff/screenshots/my_checks.png?raw=true "My Checks Page")


### PR DESCRIPTION
#### What does this PR do?
Add integration for Coveralls and add badge on README

#### Description of Task to be completed?
Add integration to [Coveralls](https://coveralls.zendesk.com/hc/en-us) to track code coverage for the project and add badge on README to indicate by a quick glance to percentage of code covered for the `develop` branch.