### PR TITLE
Ft unresolved stuff dashboard 145028383

### DIFF
--- a/hc/front/tests/test_my_checks.py
+++ b/hc/front/tests/test_my_checks.py
@@ -58,3 +58,9 @@ class MyChecksTestCase(BaseTestCase):
 
         # Mobile
         self.assertContains(r, "label-warning")
+
+    def test_failed_jobs_tab_works(self):
+        for email in ("alice@example.org", "bob@example.org"):
+            self.client.login(username=email, password="password")
+            r = self.client.get("/failed_jobs/")
+            self.assertEqual(r.status_code, 200)

--- a/hc/front/urls.py
+++ b/hc/front/urls.py
@@ -35,6 +35,8 @@ urlpatterns = [
     url(r'^checks/([\w-]+)/', include(check_urls)),
     url(r'^integrations/', include(channel_urls)),
 
+    url(r'^failed_jobs/$', views.failed_jobs, name="hc-failed-jobs"),
+
     url(r'^docs/$', views.docs, name="hc-docs"),
     url(r'^docs/api/$', views.docs_api, name="hc-docs-api"),
     url(r'^about/$', views.about, name="hc-about"),

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -60,6 +60,21 @@ def my_checks(request):
     return render(request, "front/my_checks.html", ctx)
 
 
+@login_required
+def failed_jobs(request):
+    q = Check.objects.filter(status='up').order_by("created")
+    checks = list(q)
+
+    #counter = Counter()
+    #down_tags, grace_tags = set(), set()
+    ctx = {
+        "page": "failed_jobs",
+        "checks": checks,
+        "ping_endpoint": settings.PING_ENDPOINT
+    }
+
+    return render(request, "front/my_failed_jobs.html", ctx)
+
 def _welcome_check(request):
     check = None
     if "welcome_code" in request.session:

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -62,11 +62,12 @@ def my_checks(request):
 
 @login_required
 def failed_jobs(request):
-    q = Check.objects.filter(status='up').order_by("created")
-    checks = list(q)
-
-    #counter = Counter()
-    #down_tags, grace_tags = set(), set()
+    q = Check.objects.all().order_by("created")
+    checks = []
+    for check in q:
+        status = check.get_status()
+        if status == "down":
+            checks.append(check)
     ctx = {
         "page": "failed_jobs",
         "checks": checks,

--- a/templates/base.html
+++ b/templates/base.html
@@ -77,6 +77,10 @@
                         <a href="{% url 'hc-checks' %}">Checks</a>
                     </li>
 
+                    <li {% if page == 'failed_jobs' %} class="active" {% endif %}>
+                        <a href="#">Failed Jobs</a>
+                    </li>
+
                     <li {% if page == 'channels' %} class="active" {% endif %}>
                         <a href="{% url 'hc-channels' %}">Integrations</a>
                     </li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -78,7 +78,7 @@
                     </li>
 
                     <li {% if page == 'failed_jobs' %} class="active" {% endif %}>
-                        <a href="#">Failed Jobs</a>
+                        <a href="{% url 'hc-failed-jobs' %}">Failed Jobs</a>
                     </li>
 
                     <li {% if page == 'channels' %} class="active" {% endif %}>

--- a/templates/front/my_failed_jobs.html
+++ b/templates/front/my_failed_jobs.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% load compress staticfiles %}
+
+{% block title %}My Failed Jobs - healthchecks.io{% endblock %}
+
+
+{% block content %}
+<div class="row">
+    <div class="col-sm-12">
+        <h3>
+            FAILED JOBS
+        </h3>
+    </div>
+
+</div>
+<div class="row">
+    <div class="col-sm-12">
+
+
+    {% if checks %}
+        {% include "front/my_failed_jobs_desktop.html" %}
+    {% else %}
+    <div class="alert alert-info">You don't have any failed jobs yet.</div>
+    {% endif %}
+    </div>
+</div>
+
+{% endblock %}
+
+{% block scripts %}
+{% compress js %}
+<script src="{% static 'js/jquery-2.1.4.min.js' %}"></script>
+<script src="{% static 'js/bootstrap.min.js' %}"></script>
+<script src="{% static 'js/nouislider.min.js' %}"></script>
+<script src="{% static 'js/clipboard.min.js' %}"></script>
+<script src="{% static 'js/checks.js' %}"></script>
+{% endcompress %}
+{% endblock %}

--- a/templates/front/my_failed_jobs_desktop.html
+++ b/templates/front/my_failed_jobs_desktop.html
@@ -1,0 +1,86 @@
+{% load hc_extras humanize %}
+<table id="failed-table" class="table hidden-xs">
+    <tr>
+        <th></th>
+        <th class="th-name">Name</th>
+        <th>Ping URL</th>
+        <th>Last Ping</th>
+        <th></th>
+    </tr>
+    {% for check in checks %}
+    <tr class="checks-row">
+        <td class="indicator-cell">
+            <span class="status icon-down"></span>
+        </td>
+        <td class="name-cell">
+            <div data-name="{{ check.name }}"
+                    data-tags="{{ check.tags }}"
+                    data-url="{% url 'hc-update-name' check.code %}"
+                    class="my-checks-name {% if not check.name %}unnamed{% endif %}">
+                <div>{{ check.name|default:"unnamed" }}</div>
+            </div>
+        </td>
+        <td class="url-cell">
+            <span class="my-checks-url">
+                <span class="base">{{ ping_endpoint }}</span>{{ check.code }}
+            </span>
+            <button
+                class="copy-link hidden-sm"
+                data-clipboard-text="{{ check.url }}">
+                copy
+            </button>
+        </td>
+        <td>
+        {% if check.last_ping %}
+            <span
+                data-toggle="tooltip"
+                title="{{ check.last_ping|date:'N j, Y, P e' }}">
+                {{ check.last_ping|naturaltime }}
+            </span>
+        {% else %}
+            Never
+        {% endif %}
+        </td>
+        <td>
+            <div class="check-menu dropdown">
+                <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+                <span class="icon-settings" aria-hidden="true"></span>
+                </button>
+                <ul class="dropdown-menu">
+                    <li {% if check.status == "new" or check.status == "paused" %}class="disabled"{% endif %}>
+                        <a class="pause-check"
+                           href="#"
+                           data-url="{% url 'hc-pause' check.code %}">
+                           Pause Monitoring
+                        </a>
+                    </li>
+                    <li role="separator" class="divider"></li>
+                    <li>
+                        <a href="{% url 'hc-log' check.code %}">
+                            Log
+                        </a>
+                    </li>
+                    <li>
+                        <a
+                            href="#"
+                            class="usage-examples"
+                            data-url="{{ check.url }}"
+                            data-email="{{ check.email }}">
+                            Usage Examples
+                        </a>
+                    </li>
+                    <li role="separator" class="divider"></li>
+                    <li>
+                        <a href="#" class="check-menu-remove"
+                            data-name="{{ check.name_then_code }}"
+                            data-url="{% url 'hc-remove-check' check.code %}">
+                            Remove
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </td>
+    </tr>
+    {% endfor %}
+
+</table>

--- a/templates/front/my_failed_jobs_desktop.html
+++ b/templates/front/my_failed_jobs_desktop.html
@@ -26,8 +26,7 @@
             </span>
             <button
                 class="copy-link hidden-sm"
-                data-clipboard-text="{{ check.url }}">
-                copy
+                data-clipboard-text="{{ check.url }}"
             </button>
         </td>
         <td>
@@ -40,45 +39,6 @@
         {% else %}
             Never
         {% endif %}
-        </td>
-        <td>
-            <div class="check-menu dropdown">
-                <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">
-                <span class="icon-settings" aria-hidden="true"></span>
-                </button>
-                <ul class="dropdown-menu">
-                    <li {% if check.status == "new" or check.status == "paused" %}class="disabled"{% endif %}>
-                        <a class="pause-check"
-                           href="#"
-                           data-url="{% url 'hc-pause' check.code %}">
-                           Pause Monitoring
-                        </a>
-                    </li>
-                    <li role="separator" class="divider"></li>
-                    <li>
-                        <a href="{% url 'hc-log' check.code %}">
-                            Log
-                        </a>
-                    </li>
-                    <li>
-                        <a
-                            href="#"
-                            class="usage-examples"
-                            data-url="{{ check.url }}"
-                            data-email="{{ check.email }}">
-                            Usage Examples
-                        </a>
-                    </li>
-                    <li role="separator" class="divider"></li>
-                    <li>
-                        <a href="#" class="check-menu-remove"
-                            data-name="{{ check.name_then_code }}"
-                            data-url="{% url 'hc-remove-check' check.code %}">
-                            Remove
-                        </a>
-                    </li>
-                </ul>
-            </div>
         </td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
#### What does this PR do?
- User requires a new dashboard tab for unresolved stuff
#### Description of Task to be completed?
-GIVEN that a user has been notified of a failed job
-WHEN the user logs into the dashboard
-THEN they should have a view listing all their failed jobs which they have been notified about.
#### How should this be manually tested?
- Clone the repository
- cd into the repository
- run the command `./manage.py test hc.front`  
-start server and run the app
<img width="968" alt="screen shot 2017-05-29 at 16 40 21" src="https://cloud.githubusercontent.com/assets/4943363/26551924/8f8f57a6-448d-11e7-900f-c000bf7ec782.png">
#### What are the relevant pivotal tracker stories?
- #1145028383
#### Screenshot

