### PR TITLE
Ft job running too often 145028387

### DIFF
--- a/hc/api/management/commands/sendalerts.py
+++ b/hc/api/management/commands/sendalerts.py
@@ -21,8 +21,9 @@ class Command(BaseCommand):
         now = timezone.now()
         going_down = query.filter(alert_after__lt=now, status="up")
         going_up = query.filter(alert_after__gt=now, status="down")
+        going_often = query.filter(alert_after__gt=now, status="often")
         # Don't combine this in one query so Postgres can query using index:
-        checks = list(going_down.iterator()) + list(going_up.iterator())
+        checks = list(going_down.iterator()) + list(going_up.iterator()) + list(going_often.iterator())
         if not checks:
             return False
 

--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -86,15 +86,16 @@ class Check(models.Model):
             return self.status
 
         now = timezone.now()
-        number = len(self.ping_set.all())
-        reverse_grace = self.timeout / 2
-        if number > 1:
-            previous_ping = self.ping_set.all()[number-2].created
-        else:
-            return "up"
-
-        if (self.last_ping - previous_ping) < self.timeout - reverse_grace:
-            return "often"
+        if len(self.ping_set.all().order_by('-created')) > 2:
+            reversed_grace = self.timeout / 2
+            all_pings = self.ping_set.all().order_by('-created')
+            previous_ping = all_pings[1].created
+            if self.last_ping + self.timeout + self.grace > now:
+                if (self.last_ping - previous_ping) <\
+                                                self.timeout - reversed_grace:
+                    return "often"
+                else:
+                    return "up"
 
         elif self.last_ping + self.timeout + self.grace > now:
             return "up"

--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -88,11 +88,13 @@ class Check(models.Model):
         now = timezone.now()
         number = len(self.ping_set.all())
         reverse_grace = self.timeout / 2
-        
         if number > 1:
             previous_ping = self.ping_set.all()[number-2].created
-            if (self.last_ping - previous_ping) < self.timeout - reverse_grace:
-                return "often"
+        else:
+            return "up"
+
+        if (self.last_ping - previous_ping) < self.timeout - reverse_grace:
+            return "often"
 
         elif self.last_ping + self.timeout + self.grace > now:
             return "up"

--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -86,8 +86,11 @@ class Check(models.Model):
             return self.status
 
         now = timezone.now()
+        number = len(self.ping_set.all())
+        reverse_grace = self.timeout / 2
+        previous_ping = self.ping_set.all()[number-2].created
 
-        if self.last_ping + self.timeout > now:
+        if (self.last_ping - previous_ping) < self.timeout - reverse_grace:
             return "often"
 
         elif self.last_ping + self.timeout + self.grace > now:

--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -88,10 +88,11 @@ class Check(models.Model):
         now = timezone.now()
         number = len(self.ping_set.all())
         reverse_grace = self.timeout / 2
-        previous_ping = self.ping_set.all()[number-2].created
-
-        if (self.last_ping - previous_ping) < self.timeout - reverse_grace:
-            return "often"
+        
+        if number > 1:
+            previous_ping = self.ping_set.all()[number-2].created
+            if (self.last_ping - previous_ping) < self.timeout - reverse_grace:
+                return "often"
 
         elif self.last_ping + self.timeout + self.grace > now:
             return "up"

--- a/hc/api/views.py
+++ b/hc/api/views.py
@@ -105,7 +105,7 @@ def badge(request, username, signature, tag):
             continue
 
         if check.get_status() == "often":
-            status = "often"
+            status = "down"
 
         elif status == "up" and check.in_grace_period():
             status = "late"

--- a/hc/api/views.py
+++ b/hc/api/views.py
@@ -104,7 +104,10 @@ def badge(request, username, signature, tag):
         if tag not in check.tags_list():
             continue
 
-        if status == "up" and check.in_grace_period():
+        if check.get_status() == "often":
+            status = "often"
+
+        elif status == "up" and check.in_grace_period():
             status = "late"
 
         if check.get_status() == "down":

--- a/hc/lib/badges.py
+++ b/hc/lib/badges.py
@@ -14,8 +14,9 @@ WIDTHS = {"a": 7, "b": 7, "c": 6, "d": 7, "e": 6, "f": 4, "g": 7, "h": 7,
 
 COLORS = {
     "up": "#4c1",
-    "late": "#fe7d37",
-    "down": "#e05d44"
+    "late": "#",
+    "down": "#e05d44",
+    "often": "#e05d44"
 }
 
 

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -61,6 +61,7 @@ body {
 .status.icon-up.new, .status.icon-paused { color: #CCC; }
 .status.icon-grace { color: #f0ad4e; }
 .status.icon-down { color: #d9534f; }
+.status.icon-forward3 { color: #d9534f; }
 
 .hc-dialog {
     background: #FFF;

--- a/static/css/icomoon.css
+++ b/static/css/icomoon.css
@@ -60,3 +60,7 @@
 .icon-settings:before {
   content: "\e8b8";
 }
+
+.icon-forward3:before {
+  content: "\26a1";
+}

--- a/static/fonts/icomoon.svg
+++ b/static/fonts/icomoon.svg
@@ -6,7 +6,9 @@
 <font id="icomoon" horiz-adv-x="1024">
 <font-face units-per-em="1024" ascent="960" descent="-64" />
 <missing-glyph horiz-adv-x="1024" />
+
 <glyph unicode="&#x20;" horiz-adv-x="512" d="" />
+<glyph unicode="&#x26a1;" glyph-name="forward3" d="M16 27v-10l-10 10v-22l10 10v-10l11 11z"/>
 <glyph unicode="&#xe000;" glyph-name="grace" d="M554 384.667v256h-84v-256h84zM554 212.667v86h-84v-86h84zM512 852.667c236 0 426-190 426-426s-190-426-426-426-426 190-426 426 190 426 426 426z" />
 <glyph unicode="&#xe001;" glyph-name="missing" d="M512 84.667c188 0 342 154 342 342s-154 342-342 342-342-154-342-342 154-342 342-342zM512 852.667c236 0 426-190 426-426s-190-426-426-426-426 190-426 426 190 426 426 426zM470 640.667h84v-256h-84v256zM470 298.667h84v-86h-84v86z" />
 <glyph unicode="&#xe159;" glyph-name="mail" d="M854 596.667v86l-342-214-342 214v-86l342-212zM854 768.667c46 0 84-40 84-86v-512c0-46-38-86-84-86h-684c-46 0-84 40-84 86v512c0 46 38 86 84 86h684z" />

--- a/templates/front/my_checks_desktop.html
+++ b/templates/front/my_checks_desktop.html
@@ -20,6 +20,9 @@
             {% elif check.get_status == "paused" %}
                 <span class="status icon-paused"
                     data-toggle="tooltip" title="Monitoring paused. Ping to resume."></span>
+            {% elif check.get_status == "often" %}
+                <span class="status icon-forward3"
+                    data-toggle="tooltip" title="Runs too often"></span>
             {% elif check.in_grace_period %}
                 <span class="status icon-grace"></span>
             {% elif check.get_status == "up" %}

--- a/templates/front/my_checks_desktop.html
+++ b/templates/front/my_checks_desktop.html
@@ -22,7 +22,7 @@
                     data-toggle="tooltip" title="Monitoring paused. Ping to resume."></span>
             {% elif check.get_status == "often" %}
                 <span class="status icon-forward3"
-                    data-toggle="tooltip" title="Runs too often"></span>
+                    data-toggle="tooltip" title="Job runs too often"></span>
             {% elif check.in_grace_period %}
                 <span class="status icon-grace"></span>
             {% elif check.get_status == "up" %}


### PR DESCRIPTION
#### What does this PR do?
User should be notified when a job is run too often
#### Description of Task to be completed?
We need a new notification for a job that is running too often as this is also indication of a problem with the job
Acceptance Criteria
GIVEN as a user I have a list of current active jobs
WHEN a certain job is run too often
THEN I should receive a notification to the same effect and the job get an icon and status indicating that it is running too often
#### How should this be manually tested?
-After cloning the repo cd into it and run python manage.py runserver
-open the site on a web browser and log into your user account
-Add a new check and set time out and grace periods
-Make the first ping and see that the icon for that check is the green tick for up status
-Ping the check again (within time < timeout/2) and refresh the HC page and see that the status changes to a lightning bolt for Runs too often status
#### What are the relevant pivotal tracker stories?
 Id:145028387
#### Screenshots 

<img width="1280" alt="screen shot 2017-06-07 at 09 37 51" src="https://user-images.githubusercontent.com/4943363/26865394-22d3ec60-4b65-11e7-9f78-24f47d72407d.png">
